### PR TITLE
fixed "ERROR Asset render failed"

### DIFF
--- a/source/css/bootstrap.css
+++ b/source/css/bootstrap.css
@@ -308,7 +308,7 @@ html {
 }
 
 body {
-  font-family: Helvetica Neue,Helvetica,Arial,sans-serif
+  font-family: Helvetica Neue,Helvetica,Arial,sans-serif;
   font-size: 14px;
   line-height: 1.428571429;
   color: #333333;


### PR DESCRIPTION
缺少“；”,hexo启动渲染出错
```
ERROR Asset render failed: css/bootstrap.css
CssSyntaxError: E:\blog\hexo\Gexo\themes\hipaper\source\css\bootstrap.css:311:: Missed semicolon
```

